### PR TITLE
Add version flag to CLI and implement version retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ WIP
 
 ## Usage
 
+Check the version:
+
+```bash
+python -m tickle --version
+```
+
 Scan the current directory for tasks:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.10"
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
-    "ruff>=0.1.0"
+    "ruff>=0.1.0",
+    "tomli>=2.0.0; python_version < '3.11'"
 ]
 
 [project.scripts]

--- a/src/tickle/__init__.py
+++ b/src/tickle/__init__.py
@@ -1,0 +1,20 @@
+"""Tickle - Scan repositories for outstanding developer tasks."""
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+
+    __version__ = version("tickle")
+except PackageNotFoundError:
+    # Fallback for development when not installed - read from pyproject.toml
+    try:
+        import tomllib
+    except ImportError:
+        # Python < 3.11
+        import tomli as tomllib
+
+    from pathlib import Path
+
+    _pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
+    with open(_pyproject_path, "rb") as _f:
+        _pyproject_data = tomllib.load(_f)
+    __version__ = _pyproject_data["project"]["version"]

--- a/src/tickle/cli.py
+++ b/src/tickle/cli.py
@@ -2,6 +2,7 @@
 import argparse
 from tickle.scanner import scan_directory
 from tickle.output import get_formatter
+from tickle import __version__
 
 
 def main():
@@ -32,6 +33,11 @@ def main():
         type=str,
         default="",
         help="Comma-separated list of file/directory patterns to ignore (e.g., *.min.js,node_modules)"
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}"
     )
     
     args = parser.parse_args()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,4 +135,14 @@ class TestCLI:
             
             data = json.loads(captured.out)
             assert all(item["marker"] == "TODO" for item in data)
+    
+    def test_version_flag(self, capsys):
+        """Test --version flag displays version."""
+        with mock.patch("sys.argv", ["tickle", "--version"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+            assert exc_info.value.code == 0
+            captured = capsys.readouterr()
+            assert "0.1.0" in captured.out
 


### PR DESCRIPTION
- Introduced `--version` flag to display the current version of the CLI.
- Enhanced version retrieval logic to fallback on `pyproject.toml` if not installed.
- Added a test case for the version flag functionality.