### PR TITLE
Add summary statistics feature to task scanning CLI

### DIFF
--- a/src/tickle/cli.py
+++ b/src/tickle/cli.py
@@ -1,13 +1,18 @@
 # src/tickle/cli.py
 import argparse
 
+from colorama import init as colorama_init
+
 from tickle import __version__
-from tickle.output import get_formatter
+from tickle.output import generate_stats, get_formatter
 from tickle.scanner import scan_directory
 
 
 def main():
     """Main entry point for tickle CLI."""
+    # Initialize colorama for Windows compatibility
+    colorama_init(autoreset=True)
+
     parser = argparse.ArgumentParser(
         description="Scan repositories for outstanding developer tasks (TODO, FIXME, BUG, NOTE, HACK)"
     )
@@ -36,6 +41,11 @@ def main():
         help="Comma-separated list of file/directory patterns to ignore (e.g., *.min.js,node_modules)"
     )
     parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="Show summary statistics instead of individual tasks"
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}"
@@ -53,8 +63,11 @@ def main():
     tasks = scan_directory(args.path, markers=markers, ignore_patterns=ignore_patterns)
 
     # Format and output results
-    formatter = get_formatter(args.format)
-    output = formatter.format(tasks)
+    if args.stats:
+        output = generate_stats(tasks)
+    else:
+        formatter = get_formatter(args.format)
+        output = formatter.format(tasks)
     print(output)
 
 

--- a/src/tickle/output.py
+++ b/src/tickle/output.py
@@ -110,3 +110,51 @@ def get_formatter(format_type: str) -> Formatter:
         raise ValueError(f"Unknown format type: {format_type}")
 
     return formatter_class()
+
+
+def generate_stats(tasks: list[Task]) -> str:
+    """Generate summary statistics for tasks.
+
+    Args:
+        tasks: List of Task objects to analyze.
+
+    Returns:
+        Formatted string with statistics summary.
+    """
+    if not tasks:
+        return "No tasks found!"
+
+    # Total count
+    total = len(tasks)
+
+    # Count by marker type
+    marker_counts = {}
+    for task in tasks:
+        marker_counts[task.marker] = marker_counts.get(task.marker, 0) + 1
+
+    # Count by file
+    file_counts = {}
+    for task in tasks:
+        file_counts[task.file] = file_counts.get(task.file, 0) + 1
+
+    # Sort markers and files by count (descending)
+    sorted_markers = sorted(marker_counts.items(), key=lambda x: x[1], reverse=True)
+    sorted_files = sorted(file_counts.items(), key=lambda x: x[1], reverse=True)
+
+    # Build output
+    lines = []
+    lines.append(f"Total Tasks: {total}")
+
+    # Marker breakdown with colors
+    marker_parts = []
+    for marker, count in sorted_markers:
+        color = MARKER_COLORS.get(marker, Fore.WHITE)
+        marker_parts.append(f"{color}{marker}{Style.RESET_ALL}: {count}")
+    lines.append(", ".join(marker_parts))
+
+    # Top files (show top 5)
+    top_files = sorted_files[:5]
+    file_parts = [f"{file} ({count})" for file, count in top_files]
+    lines.append(f"Top Files: {', '.join(file_parts)}")
+
+    return "\n".join(lines)


### PR DESCRIPTION
- Introduced `--stats` argument to display summary statistics instead of individual tasks.
- Implemented `generate_stats` function to calculate and format task statistics.
- Enhanced main function to handle new statistics output.

Closes issue #11 